### PR TITLE
Resolves issue #14 dtproj.user is not required

### DIFF
--- a/src/SsisBuild.Core/Builder/SsisBuildPowershell.cs
+++ b/src/SsisBuild.Core/Builder/SsisBuildPowershell.cs
@@ -81,7 +81,7 @@ namespace SsisBuild.Core.Builder
                 string.IsNullOrWhiteSpace(NewPassword) ? null : NewPassword,
                 string.IsNullOrWhiteSpace(Configuration) ? null : Configuration,
                 string.IsNullOrWhiteSpace(ReleaseNotes) ? null : ReleaseNotes,
-                Parameters.OfType<DictionaryEntry>().ToDictionary(e => e.Key as string, e => e.Value as string)
+                Parameters?.OfType<DictionaryEntry>().ToDictionary(e => e.Key as string, e => e.Value as string)
             );
 
             _builder = _builder ?? new Builder();

--- a/src/SsisBuild.Core/ProjectManagement/Project.cs
+++ b/src/SsisBuild.Core/ProjectManagement/Project.cs
@@ -318,9 +318,9 @@ namespace SsisBuild.Core.ProjectManagement
 
             var userConfigurationFilePath = $"{filePath}.user";
             var userConfiguration = new UserConfiguration(configurationName);
-            userConfiguration.Initialize(userConfigurationFilePath, password);
             if (File.Exists(userConfigurationFilePath))
             {
+                userConfiguration.Initialize(userConfigurationFilePath, password);
                 foreach (var userConfigurationParameter in userConfiguration.Parameters)
                 {
                     UpdateParameter(userConfigurationParameter.Key, null, ParameterSource.Configuration);


### PR DESCRIPTION
Do not require -Paramaters if none are necessary, do not require dtproj.user file to exist if no parameters are stored there

-Parameters powershell param should not be required


