### PR TITLE
Make the dtproj.user file optional

### DIFF
--- a/src/SsisBuild.Core/ProjectManagement/Project.cs
+++ b/src/SsisBuild.Core/ProjectManagement/Project.cs
@@ -317,10 +317,10 @@ namespace SsisBuild.Core.ProjectManagement
             }
 
             var userConfigurationFilePath = $"{filePath}.user";
-            var userConfiguration = new UserConfiguration(configurationName);
-            userConfiguration.Initialize(userConfigurationFilePath, password);
             if (File.Exists(userConfigurationFilePath))
             {
+                var userConfiguration = new UserConfiguration(configurationName);
+                userConfiguration.Initialize(userConfigurationFilePath, password);
                 foreach (var userConfigurationParameter in userConfiguration.Parameters)
                 {
                     UpdateParameter(userConfigurationParameter.Key, null, ParameterSource.Configuration);


### PR DESCRIPTION
Usually it is best practice not to commit the *.dtproj.user file as it is user specific and just personal preferences (see https://stackoverflow.com/questions/7756620/what-files-should-i-check-in-for-an-ssis-project and https://docs.microsoft.com/en-us/sql/integration-services/integration-services-ssis-projects-and-solutions)

This solves #14.