### PR TITLE
Support the default ProtectionLevel EncryptSensitiveWithUserKey

### DIFF
--- a/src/SsisBuild.Core/ProjectManagement/Package.cs
+++ b/src/SsisBuild.Core/ProjectManagement/Package.cs
@@ -47,10 +47,13 @@ namespace SsisBuild.Core.ProjectManagement
         {
             _protectionLevelAttribute = FileXmlDocument.SelectSingleNode("/DTS:Executable", NamespaceManager)?.Attributes?["DTS:ProtectionLevel"];
 
+            // At least in Visual Studio 2017 (14.0.0800.98), the DTS:ProtectionLevel elemented is ommited in case it is set to DontSaveSensitive.
+            if (_protectionLevelAttribute == null) {
+                var attr = FileXmlDocument.CreateAttribute("DTS:ProtectionLevel");
+                attr.Value = "DontSaveSensitive";
+                _protectionLevelAttribute = attr;
+            }
             var protectionLevelValue = _protectionLevelAttribute?.Value;
-
-            if (protectionLevelValue == null)
-                throw new InvalidXmlException("Failed to determine protection level. DTS:ProtectionLevel attribute was not found.", FileXmlDocument);
 
             ProtectionLevel protectionLevel;
             if (!Enum.TryParse(protectionLevelValue, true, out protectionLevel))

--- a/src/SsisBuild.Core/ProjectManagement/ProjectManifest.cs
+++ b/src/SsisBuild.Core/ProjectManagement/ProjectManifest.cs
@@ -131,7 +131,8 @@ namespace SsisBuild.Core.ProjectManagement
             if (!Enum.TryParse(protectionLevelString, out protectionLevel))
                 throw new InvalidXmlException($"Invalid Protection Level {protectionLevelString}.", manifestXml);
 
-            if (protectionLevel == ProtectionLevel.EncryptAllWithUserKey || protectionLevel == ProtectionLevel.EncryptSensitiveWithUserKey)
+            // EncryptAllWithUserKey cannot be decrypted. However, in case of EncryptSensitiveWithUserKey we just loose the sensitive information.
+            if (protectionLevel == ProtectionLevel.EncryptAllWithUserKey)
                 throw new InvalidProtectionLevelException(protectionLevel);
 
             _protectionLevelNodes.Add(projectProtectionLevelAttribute);


### PR DESCRIPTION
EncryptSensitiveWithUserKey is the default and thus used by many developers. I found out that the DTS:ProtectionLevel attribute in the dtsx file is only set if it differs from EncryptSensitiveWithUserKey.