### PR TITLE
Project file may be outdated with regard to name

### DIFF
--- a/src/SsisBuild.Core/ProjectManagement/ProjectManifest.cs
+++ b/src/SsisBuild.Core/ProjectManagement/ProjectManifest.cs
@@ -278,9 +278,9 @@ namespace SsisBuild.Core.ProjectManagement
             {
                 foreach (XmlNode packageParameterXmlNode in packageParameterXmlNodes)
                 {
-                    var packageName = packageParameterXmlNode.SelectSingleNode("../../SSIS:Properties/SSIS:Property[@SSIS:Name = \"Name\"]", NamespaceManager)?.InnerText;
+                    var packageName = packageParameterXmlNode.SelectSingleNode("../../@SSIS:Name", NamespaceManager).Value;
                     
-                    parameters.Add(new ProjectParameter(packageName, packageParameterXmlNode));
+                    parameters.Add(new ProjectParameter(packageName.Remove(packageName.Length - 5), packageParameterXmlNode));
                 }
             }
 


### PR DESCRIPTION
When one copies a dtsx package in the solution explorer. The name is not updated right away in the updated package. One has to open the package and change something or rename it. Otherwise the project contains two packages with the same Name attribute in dtproj file. This made ssis-build.exe crash.