### PR TITLE
#22 Applies default protection level (EncryptSensitiveWithUserKey) 

### DIFF
--- a/src/SsisBuild.Core/ProjectManagement/Package.cs
+++ b/src/SsisBuild.Core/ProjectManagement/Package.cs
@@ -50,7 +50,8 @@ namespace SsisBuild.Core.ProjectManagement
             var protectionLevelValue = _protectionLevelAttribute?.Value;
 
             if (protectionLevelValue == null)
-                throw new InvalidXmlException("Failed to determine protection level. DTS:ProtectionLevel attribute was not found.", FileXmlDocument);
+                protectionLevelValue = "1"; //Default is EncryptSensitiveWithUserKey
+                //throw new InvalidXmlException("Failed to determine protection level. DTS:ProtectionLevel attribute was not found. " + FileXmlDocument.BaseURI?.ToString(), FileXmlDocument);
 
             ProtectionLevel protectionLevel;
             if (!Enum.TryParse(protectionLevelValue, true, out protectionLevel))


### PR DESCRIPTION
#22 Applies default protection level (EncryptSensitiveWithUserKey) when it's not explicitly defined in package file.
[https://github.com/rtumaykin/ssis-build/issues/22](url)