### PR TITLE
Fixed double copy of references

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 2.3.1 (Released 2019/10/10)
+* Fixed double copy of references
+
 #### 2.3.0 (Released 2019/03/29)
 * Added parameter data type validations
 

--- a/SsisBuild.nuspec
+++ b/SsisBuild.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>SSISBuild</id>
-    <version>2.1.2</version>
+    <version>2.3.1</version>
     <title>SSIS Build</title>
     <authors>Roman Tumaykin</authors>
     <owners>Roman Tumaykin</owners>
@@ -10,8 +10,7 @@
     <projectUrl>https://github.com/rtumaykin/ssis-build/</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A set of utilities that allow to autonomously build a Visual Studio SSIS project (dtproj) into a deployment package (ispac), and deploy the package to an SSIS catalog.</description>
-    <releaseNotes>Added powershell parameters documentation
-Made Catalog and ProjectName parameters Optional in deployer</releaseNotes>
+    <releaseNotes>Fixed double copy of references</releaseNotes>
     <copyright>Copyright © 2017 Roman Tumaykin</copyright>
     <tags>SSIS build tools</tags>
   </metadata>
@@ -19,7 +18,7 @@ Made Catalog and ProjectName parameters Optional in deployer</releaseNotes>
     <file src="src\SsisBuild\bin\$configuration$\*.dll" target="tools" />
     <file src="src\SsisBuild\bin\$configuration$\ssisbuild.exe" target="tools" />
     <file src="src\SsisBuild\bin\$configuration$\ssisbuild.exe.config" target="tools" />
-    <file src="src\SsisDeploy\bin\$configuration$\*.dll" target="tools" exclude="**\SsisBuild.Core.dll;**\SsisBuild.Logger.dll" />
+    <file src="src\SsisDeploy\bin\$configuration$\*.dll" target="tools" exclude="**\SsisBuild.Core.dll;**\SsisBuild.Logger.dll;**\Microsoft.Management.Infrastructure.dll;**\System.Management.Automation.dll" />
     <file src="src\SsisDeploy\bin\$configuration$\ssisdeploy.exe" target="tools" />
     <file src="src\SsisDeploy\bin\$configuration$\ssisdeploy.exe.config" target="tools" />
   </files>

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Roman Tumaykin")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2017 Roman Tumaykin")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("2.3.0.0")]
-[assembly: AssemblyFileVersionAttribute("2.3.0.0")]
+[assembly: AssemblyVersionAttribute("2.3.1.0")]
+[assembly: AssemblyFileVersionAttribute("2.3.1.0")]


### PR DESCRIPTION
2 dlls are added twice to the NuGet package:
Microsoft.Management.Infrastructure.dll
System.Management.Automation.dll

Effectively tools like Paket cannot use this package. One can verify the structure with 7-zip or other tool.
This PR adds excludes to avoid duplication.